### PR TITLE
Delete `REQUIRE` file

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 0.7+
-JuliaInterpreter
-MacroTools
-Debugger


### PR DESCRIPTION
Now that there is a `Project.toml` file in the repository, the `REQUIRE` file is no longer relevant and can be deleted.